### PR TITLE
KNJ-6904 promocode offers default sorting and small fixes

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1375,14 +1375,14 @@ feature                         | supported by resource
 This resource supports [paging](#header-paging). The attribute `id` will be used as the value for `before` or `after` parameter.
 
 #### Sorting
-Resource does not support manual sorting, default sorting is by `created_at descending`.
+Resource does not support manual sorting, default sorting is by `priority descending, createdAt descending`.
 
 #### Filtering
 This resource supports [filtering](#header-filtering). You can use following filters:
 
 filter name        | possible operators | example
 ---                | ---                | ---
-id                 |eq,in               | `applications?filter=id|in|1,3` transactions that have id 1 or 3
+id                 |eq,in               | `offers?filter=id|in|1,3` transactions that have id 1 or 3
 
 + Request (application/json; charset=utf-8)
 
@@ -2420,7 +2420,8 @@ Promocode offer - voucher offered to customer
 + voucherValidFrom: `2019-01-18T10:34:44+01:00` (string, optional, nullable) - Display info about voucher validity - starting datetime
 + voucherValidUntil: `2020-01-18T10:34:44+01:00` (string, optional, nullable) - Display info about voucher validity - ending info
 + descriptionShort: `Sleva 55%` (string, optional, nullable) - Display short info about a value of the voucher
-+ eshopAddtionalInfo (EshopAdditionalInfo, optional) - Display info about partner
++ eshopAddtionalInfo (EshopAdditionalInfo, required) - Display info about partner
+    + `name`: `Mall.cz` (string, required) - marketing name of eshop used in connection with application
     
 ## PurchasedPartnerPromocodeOffer (object)
 Promocode offer purchased by a customer


### PR DESCRIPTION
- partner promocode offers are now by default sorted by priority
descending, createdAt descending
- fix example URL query in partner promocode filtering
- made eshopAdditionalInfo.name required in partner promocode offer